### PR TITLE
Issue with Spatial Calib Script

### DIFF
--- a/core/wifisSpatialCor.py
+++ b/core/wifisSpatialCor.py
@@ -1163,12 +1163,14 @@ def extendTraceSlice2(input):
         #identify corresponding spatial coordinate from Ronchi interpolation
         #using linear interpolation for increased precision (as trace likely falls between two grid points)
         for i in range(zero.shape[0]):
-            
-            ia = np.floor(zero[i]).astype('int')
-            ib = ia+1
-            za= zPad[ia+1,i]
-            zb = zPad[ib+1,i]
-            zeroInterp[i] = (zero[i]-ia)*zb + (ib-zero[i])*za
+            if np.isnan(zero[i]):
+                zeroInterp[i] = 0.0
+            else:
+                ia = np.floor(zero[i]).astype('int')
+                ib = ia+1
+                za= zPad[ia+1,i]
+                zb = zPad[ib+1,i]
+                zeroInterp[i] = (zero[i]-ia)*zb + (ib-zero[i])*za
 
         #now subtract the zero value from each point to place on absoluate grid
         z -= zeroInterp
@@ -1190,7 +1192,6 @@ def extendTraceAll2(traceLst, extSlices, zeroTraces,space=1/15.,order=1,method='
     """
 
     #setup input list
-
     if (MP ==False):
         interpLst = []
 

--- a/core/wifisWaveSol.py
+++ b/core/wifisWaveSol.py
@@ -513,6 +513,9 @@ def getSolQuick(input):
                                         #amp,cent,wid = splineFit(pixRng, yRng, plot=plot,title=str(atlasPix[i]))
                                         #amp,cent,wid = gaussFit(pixRng,yRng, winRngTmp/3.,plot=plot,title=str(atlasPix[i]))
                                         amp,cent,wid = polyGaussFit(pixRng,yRng, winRngTmp/3.,plot=plot,title=str(atlasPix[i]))
+                                        if cent > 3000:
+                                            mpl.plot(pixRng, yRng)
+                                            mpl.show()
 
                                         #get weighted average as well
                                         #cent2 = getWeightedCent(pixRng,yRng)
@@ -886,7 +889,7 @@ def getWaveSol (dataSlices, templateSlices,atlas, mxorder, prevSol, winRng=7, mx
             for j in range(dataLst[i].shape[0]):
                 lst.append([dataLst[i][j,:],tmpLst[i], bestLines, mxorder,prevSol[i],winRng, mxCcor,weights, plot, buildSol, allowLower, sigmaClip,lngthConstraint, adjustFitWin,sigmaLimit, allowSearch,int(sigmaClipRounds),nPixContFit,nSearchRounds])
                 
-
+    #MP = False
     if (MP):
         #setup multiprocessing routines
         if (ncpus == None):


### PR DESCRIPTION
When reducing some spatial calibrations I ran into an issue in wifisSpatialCor for the function extendTraceSlice2 on line 1215. At the end of this function there is a loop over an array called "zero". For the final slice some of the values in "zero" were NaN which, when processed by the floor function on line 1167 in the original, leads to a massive integer and an index error. 

I hacked this to work by just checking for NaNs and setting the result to zero, but I imagine theres a better solution.

------
Don't pay attention to the change to wifisWaveSol, that was just to handle another random error I was encountering that I discussed with Jason. 